### PR TITLE
feat: add V3 Pro support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ This project can be used in two ways:
 
 Because I only have one Basilisk V3 (Wired) mouse, and other models are somewhat expensive, this project only supports this specific model now. For models such as "Ultimate" "Pro" "35K", it is currently NOT supported. However I believe the protocols are mostly the same. With little modification it may be possible to work just fine. Nevertheless I cannot ensure it is usable, and I can't be responsible if it breaks your mouse.
 
+According to another user's experience, the V3 Pro model supports the same protocol.
+
 ## 编译和运行 / Compiling and Running
 
 ### 本地运行 python 脚本 / Run python scripts locally

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@
 
 因为我只有Razer Basilisk V3 (雷蛇巴蛇V3，有线版) 这一款鼠标，其他的比较贵我没有买，所以目前只支持这一款。诸如无线版，什么终级版、专业版、35K 现在都**不**支持，但是我相信它们的协议都是差不多的，稍微修改一下，有可能可以正常运行，但是我不对可用性做保证，弄坏了也没法负责。
 
+[AlexDaichendt](https://github.com/AlexDaichendt) 指出 V3 Pro 使用的协议和 V3 是一样的，现在已经一并在网页应用中实现了。我发现这两个型号还是有些小区别的，如果有什么问题的话，欢迎提出贡献。
+
 Changes configuration of Razer Basilisk V3 with analyzed reverse-engineered protocol. The project doesn't use proprietary code in Razer Synapse software. It uses python with [libusb/hidapi](https://github.com/libusb/hidapi) to communicate with the mouse, so it's cross-platform.
 
 The implementation is easy, and its main functionality is to be able to bind mouse buttons with on board memory, and can read and alter macros, which other softwares haven't implemented.
@@ -29,7 +31,7 @@ This project can be used in two ways:
 
 Because I only have one Basilisk V3 (Wired) mouse, and other models are somewhat expensive, this project only supports this specific model now. For models such as "Ultimate" "Pro" "35K", it is currently NOT supported. However I believe the protocols are mostly the same. With little modification it may be possible to work just fine. Nevertheless I cannot ensure it is usable, and I can't be responsible if it breaks your mouse.
 
-According to another user's experience, the V3 Pro model supports the same protocol.
+[AlexDaichendt](https://github.com/AlexDaichendt) stated that according to his experience, the V3 Pro model supports the same protocol and it's intergrated into the webapp now. I noticed there are some subtle differences on RGB lighting and sensor between V3 and V3 Pro. Contributions are welcome if you find problems.
 
 ## 编译和运行 / Compiling and Running
 
@@ -45,11 +47,11 @@ Download [libusb/hidapi](https://github.com/libusb/hidapi) and put it in a place
 
 ### 网页应用 / Web app
 
-直接访问 GitHub 简介下方的网址即可使用，需要[浏览器支持 WebHID API](https://developer.mozilla.org/en-US/docs/Web/API/WebHID_API#browser_compatibility)。如果要开发本项目的话，首先 `git clone` 本仓库到本地，在项目根目录下使用 Node.js `npm install` 以后，使用 `npm run dev` 启动开发服务器，即可使用。也可以使用 `npm run build` 编译生成静态网页。
+直接访问 GitHub 简介下方的网址即可使用，需要[浏览器支持 WebHID API](https://developer.mozilla.org/en-US/docs/Web/API/WebHID_API#browser_compatibility)。如果要开发本项目的话，首先 `git clone` 本仓库到本地，在项目根目录下使用 Node.js `npm install` 以后，需要在项目中添加 pyodide 库，可以通过执行 `mkdir -p ./public/pyodide && wget -O - https://github.com/pyodide/pyodide/releases/download/0.26.2/pyodide-core-0.26.2.tar.bz2 | tar -xvj -C ./public/pyodide --strip-components=1` 直接下载并解压到对应目录中。使用 `npm run dev` 启动开发服务器，即可使用。也可以使用 `npm run build` 编译生成静态网页。
 
 网页应用的代码包括 `src` 目录下 Vue.js 编写的网页前端，它通过 [Pyodide](https://github.com/pyodide/pyodide) 在浏览器中运行 [public/py 目录](./public/py/)下的 python 脚本，并使用 WebHID API 实现与 hidapi 相同的接口，以达到免去后端运行的目的。因此，两种运行方式共享一套 python 编写的协议实现。
 
-It is usable with the link below github description. It needs the [browser to support WebHID API](https://developer.mozilla.org/en-US/docs/Web/API/WebHID_API#browser_compatibility). If you need to develop this project, first `git clone` this repo. Then `npm install` with Node.js in the project root. Start the development server with `npm run dev` and it should work. You can also use `npm run build` to generate static pages.
+It is usable with the link below github description. It needs the [browser to support WebHID API](https://developer.mozilla.org/en-US/docs/Web/API/WebHID_API#browser_compatibility). If you need to develop this project, first `git clone` this repo. Then `npm install` with Node.js in the project root. You will need to download pyodide library in the project directory by running the command `mkdir -p ./public/pyodide && wget -O - https://github.com/pyodide/pyodide/releases/download/0.26.2/pyodide-core-0.26.2.tar.bz2 | tar -xvj -C ./public/pyodide --strip-components=1`. Start the development server with `npm run dev` and it should work. You can also use `npm run build` to generate static pages.
 
 The web app includes codes in `src` folder written with Vue.js. It runs python scripts located in [public/py folder](./public/py/) in the browser through [Pyodide](https://github.com/pyodide/pyodide). The same interface of hidapi library is reimplemented with WebHID API to eliminate the need of a backend server. Therefore, two ways of running share a same implementation of the protocol with Python.
 

--- a/public/py/basilisk_v3/device.py
+++ b/public/py/basilisk_v3/device.py
@@ -88,12 +88,13 @@ class BasiliskV3Device(Device):
 
 class BasiliskV3ProDevice(BasiliskV3Device):
     """
-    Basilisk V3 Pro with PID 0x00AB (171)
+    Basilisk V3 Pro with PID 0x00AA (wired) or 0x00AB (wireless)
     Supports the same protocol as BasiliskV3Device but with different PID
     """
 
     vid = 0x1532
-    pid = 0x00AB
+    pid = 0x00AA
+    pid_wireless = 0x00AB
     ifn = 3
     
     def _fix_interface_number(self, it):
@@ -104,7 +105,7 @@ class BasiliskV3ProDevice(BasiliskV3Device):
         # Not sure if this is needed for all devices or just my combination of hardware and software.
         # V3 Pro on this hardware+software combination reports as it["usage_page"]===1 instead of 12
         fio = tuple(it.get("fio_count") or ())
-        if it.get("interface_number", -1) == -1 and self.pid == it["product_id"] and self.vid == it["vendor_id"]:
+        if it.get("interface_number", -1) == -1 and (self.pid == it["product_id"] or self.pid_wireless == it["product_id"]) and self.vid == it["vendor_id"]:
             if len(fio) >= 1 and fio[0] > 0:
                 it["interface_number"] = self.ifn
         return it

--- a/src/components/ConnectDevice.vue
+++ b/src/components/ConnectDevice.vue
@@ -27,20 +27,18 @@ async function requestDevice(){
         BasiliskV3Device.sr_with = sr_with
 
     # Try connecting with the new PID (0x00AB) first, then fall back to old PID (0x0099)
+    hid.webhid_request_device()
     device = None
     for DeviceClass in [BasiliskV3ProDevice, BasiliskV3Device]:
         try:
             device = DeviceClass()
-            if custom_path is not None:
-                hid.enumerate()
             device.connect(path=custom_path)
             print('Connected with device:', DeviceClass.__name__)
             break
         except Exception as e:
             print(f'Failed to connect with {DeviceClass.__name__}: {e}')
             continue
-
-    if device is None:
+    else:
         raise RuntimeError('Could not connect to any device')
 
     print('device created', device.get_serial())

--- a/src/components/ConnectDevice.vue
+++ b/src/components/ConnectDevice.vue
@@ -85,7 +85,7 @@ const isPythonReady = computed(() => {
     <h1><img src="/snakemouse.svg" class="inline h-[1em]" />Razer Basilisk V3 Onboard Memory Tools</h1>
     <div>Browser must support WebHID to work, Click "Connect to mouse" and select device</div>
     <div>Select Razer Basilisk V3 or (1532:0099)</div>
-    <div>V3 Pro is also supported (1532:00AB)</div>
+    <div>V3 Pro is also supported (1532:00AA, 1532:00AB)</div>
     <div><a href="https://developer.mozilla.org/en-US/docs/Web/API/WebHID_API#browser_compatibility" class="link">You browser</a> <span class="bg-success text-success-content" v-if="hasHid()">probably supports WebHID</span><span class="bg-error text-error-content" v-else>does not support WebHID</span></div>
     <button class="btn btn-primary block w-96" @click="requestDevice" :class="{'btn-disabled': !isPythonReady}">Connect to mouse</button>
     <button class="btn block w-96" @click="noHardwareMode" :class="{'btn-disabled': !isPythonReady}">Use without actual mouse</button>

--- a/src/components/ConnectDevice.vue
+++ b/src/components/ConnectDevice.vue
@@ -85,6 +85,7 @@ const isPythonReady = computed(() => {
     <h1><img src="/snakemouse.svg" class="inline h-[1em]" />Razer Basilisk V3 Onboard Memory Tools</h1>
     <div>Browser must support WebHID to work, Click "Connect to mouse" and select device</div>
     <div>Select Razer Basilisk V3 or (1532:0099)</div>
+    <div>V3 Pro is also supported (1532:00AB)</div>
     <div><a href="https://developer.mozilla.org/en-US/docs/Web/API/WebHID_API#browser_compatibility" class="link">You browser</a> <span class="bg-success text-success-content" v-if="hasHid()">probably supports WebHID</span><span class="bg-error text-error-content" v-else>does not support WebHID</span></div>
     <button class="btn btn-primary block w-96" @click="requestDevice" :class="{'btn-disabled': !isPythonReady}">Connect to mouse</button>
     <button class="btn block w-96" @click="noHardwareMode" :class="{'btn-disabled': !isPythonReady}">Use without actual mouse</button>


### PR DESCRIPTION
Hey, 

I was able to use this excellent software to interact with my V3 Pro on Linux. Thank you so much for putting it up and commenting on the polychromatic repo, otherwise I would have never found it. 

There were some smaller modifications required to get it to work:
- Introduce a new BasiliskV3ProDevice with the changed pid
- Change the initialization logic to also probe the v3 pro device
- A tiny fix for my browser not being able to open a hid connection. 

There could be a debate if we should unify the browser hid logic, but I dont have the hardware (and time) to test it across more device, hence I added my workaround only to the new device. This is probably related to #3. 

The Chinese parts of the readme probably need to be adjusted but I do not feel confident to do that. 